### PR TITLE
Get all selected options from select-multiple element

### DIFF
--- a/src/json-formdata.js
+++ b/src/json-formdata.js
@@ -188,6 +188,10 @@
               }
             }
           });
+        } else if(field.type === 'select-multiple'){
+          [].forEach.call(field.selectedOptions, function(option){
+            self.putFormData(field.name + '[]', option.value);
+          });
         } else if(!isCheckable || (isCheckable && field.checked)) {
           self.putFormData(field.name, field.value);
         }


### PR DESCRIPTION
"select" form elements with the "multiple" attribute can have more than one option selected. At this moment only the first selected option is put in the json-object. This fix loops over all selected options and adds them in an array.

Example:
```html
<select id="mySelect" multiple>
  <option>Apple</option>
  <option>Pear</option>
  <option>Banana</option>
  <option>Orange</option>
</select>
```