### PR TITLE
Fixed buttons issue: now buttons are skipped

### DIFF
--- a/src/json-formdata.js
+++ b/src/json-formdata.js
@@ -177,7 +177,7 @@
     [].forEach.call(fields, function (field, index) {
       safeIndex = index;
       isCheckable = (field.type === 'checkbox' || field.type === 'radio');
-      isButton = (field.type === 'button' || field.type === 'reset' || field.type === 'submit');
+      isButton = (field.type === 'button' || field.type === 'reset' || field.type === 'submit' || field.nodeName.toLowerCase() === 'button');
 
       if (!isButton) {
         if (field.type === 'file' && !!field.files.length) {

--- a/src/json-formdata.js
+++ b/src/json-formdata.js
@@ -169,15 +169,17 @@
         fieldsLn = fields.length - 1,
         hasFiles = false,
         safeIndex = null,
-        isCheckable = false;
+        isCheckable = false,
+        isButton = false;
 
     self.formData = {};
 
     [].forEach.call(fields, function (field, index) {
       safeIndex = index;
       isCheckable = (field.type === 'checkbox' || field.type === 'radio');
+      isButton = (field.type === 'button' || field.type === 'reset' || field.type === 'submit');
 
-      if (field.type !== 'submit') {
+      if (!isButton) {
         if (field.type === 'file' && !!field.files.length) {
           hasFiles = true;
           self.fileToJSON(field.files, field.name, function (err) {

--- a/test/spec/json-formdata-spec.js
+++ b/test/spec/json-formdata-spec.js
@@ -179,4 +179,20 @@ describe('JSONFormData', function() {
 
     expect(formData).toEqual(jasmine.objectContaining(expected));
   });
+
+
+  it('Does not include buttons', function() {
+
+    formFixture.innerHTML =
+      '<input name=\'these\' value=\'buttons\' type=\'button\'>'+
+      '<input name=\'have\' value=\'not\' type=\'reset\'>'+
+      '<button name=\'to\' value=\'be\' type=\'reset\'>Button</button>' +
+      '<button name=\'included\' value="!" type=\'button\'>Button</button>';
+
+    var formData = new JSONFormData(formFixture).formData;
+
+    var expected = {};
+    expect(formData).toEqual({});
+  });
+
 });

--- a/test/spec/json-formdata-spec.js
+++ b/test/spec/json-formdata-spec.js
@@ -180,7 +180,7 @@ describe('JSONFormData', function() {
     expect(formData).toEqual(jasmine.objectContaining(expected));
   });
 
-
+  //We wants to skip <button> elements and also <input type="submit|reset|button">. See discussion on commit f7340be32d0b8b186fdcf75df4671e65baed9420
   it('Supports button skipping', function() {
 
     formFixture.innerHTML =

--- a/test/spec/json-formdata-spec.js
+++ b/test/spec/json-formdata-spec.js
@@ -181,13 +181,15 @@ describe('JSONFormData', function() {
   });
 
 
-  it('Does not include buttons', function() {
+  it('Supports button skipping', function() {
 
     formFixture.innerHTML =
-      '<input name=\'these\' value=\'buttons\' type=\'button\'>'+
-      '<input name=\'have\' value=\'not\' type=\'reset\'>'+
-      '<button name=\'to\' value=\'be\' type=\'reset\'>Button</button>' +
-      '<button name=\'included\' value="!" type=\'button\'>Button</button>';
+    '<input name=\'name1\' value=\'value1\' type=\'submit\'>'+
+    '<button name=\'name2\' value="value2">Button</button>' +
+    '<input name=\'these\' value=\'buttons\' type=\'button\'>'+
+    '<input name=\'have\' value=\'not\' type=\'reset\'>'+
+    '<button name=\'to\' value=\'be\' type=\'reset\'>Button</button>' +
+    '<button name=\'included\' value="!" type=\'button\'>Button</button>';
 
     var formData = new JSONFormData(formFixture).formData;
 


### PR DESCRIPTION
Hi there,

[I was having problems](https://github.com/roman01la/JSONFormData/issues/6) with buttons in my form, I debugged the source code and I found that buttons are getting included in the JSON object.

I took a look to the specification draft but buttons are not mentioned. In HTML form, to my knowledge, the only button submitted is the `type="submit"` button used to submit the form, but in this context the form is submitted by javascript so I don't think is necessary to include buttons.

I also updated the test file adding a test for showing the issue. The actual code fails the test.

I hope this will be a little helpful,

Marco

PS I'm quite new to code contribution so be patient if I did something wrong