### PR TITLE
Added disabled fields skipping

### DIFF
--- a/src/json-formdata.js
+++ b/src/json-formdata.js
@@ -179,7 +179,7 @@
       isCheckable = (field.type === 'checkbox' || field.type === 'radio');
       isButton = (field.type === 'button' || field.type === 'reset' || field.type === 'submit' || field.nodeName.toLowerCase() === 'button');
 
-      if (!isButton) {
+      if (!isButton && !field.disabled) {
         if (field.type === 'file' && !!field.files.length) {
           hasFiles = true;
           self.fileToJSON(field.files, field.name, function (err) {

--- a/test/spec/json-formdata-spec.js
+++ b/test/spec/json-formdata-spec.js
@@ -194,7 +194,23 @@ describe('JSONFormData', function() {
     var formData = new JSONFormData(formFixture).formData;
 
     var expected = {};
-    expect(formData).toEqual({});
+    expect(formData).toEqual(expected);
+  });
+
+  //We wants to skip elements with disabled attribute. See issue: https://github.com/roman01la/JSONFormData/issues/11
+  it('Supports disabled skipping', function() {
+
+    formFixture.innerHTML =
+    '<input name=\'name1\' value=\'value1\' type=\'text\' disabled>'+
+    '<input name=\'name2\' value=\'value2\' type=\'text\' disabled="disabled">'+
+    '<input name=\'name3\' value=\'value3\' type=\'text\' disabled="whatever">'+
+    '<input name=\'name4\' value=\'value4\' type=\'text\' disabled="">'+
+    '<input name=\'name5\' value=\'value5\' type=\'text\'>';
+
+    var formData = new JSONFormData(formFixture).formData;
+
+    var expected = {'name5':'value5'};
+    expect(formData).toEqual(expected);
   });
 
 });


### PR DESCRIPTION
Added skipping of disabled elements as discussed with also the test. DOM `disabled` attribute is really handy. Only tested on Chrome